### PR TITLE
Simpliefied core service communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,99 @@ The project has the following dependencies:
 * JRE/JDK 11 [Download from here](https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html)
 * Maven 3.5+ [Download from here](http://maven.apache.org/download.cgi) | [Install guide](https://www.baeldung.com/install-maven-on-windows-linux-mac)
 * GitHub Packages [Configuring Maven for GitHub Packages](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-apache-maven-for-use-with-github-packages)
+
+### Changes in this version
+* Orchestrator class implemented (request orchestration with this class):
+    * use with @Autowired injection
+    * orchestration flags can defined via application.properties (changes during runtime always possible)
+    * searching with version can be disabled or enabled by application.properties (changes during runtime always possible)
+    * minimal and maximal version can defined in application.properties (changes during runtime always possible)
+    * it is possible to define how many times the orchestration can fail and how long it has to wait until next try (changes during runtime always possible)
+* Service Registry class implemented (request register/unregister a service with this class):
+    * use with @Autowired injection
+    * register a service or any other services which are not part of the client
+    * unregister a service
+    * external services cannot register with 0.0.0.0 or 169.x.x.x addresses
+    * services with 0.0.0.0 address will be automatically registered with all available addresses
+    * defines for this class from application.properties can be changed during runtime
+* Event Handler class implemented (publish an/subscribe to/unsubscribe from event with this class):
+    * use with @Autowired injection
+    * use to register a/subscribe to/unsubscribe from an event
+    * predefined options from application.properties can be change during runtime
+* ConfigEventProperties class implemented:
+    * map defined events in application.properties to Key-Value-Map for Event Handler (automapping)
+    * it is used for publisher and subscriber
+* implemented SenML class for easy access and as easy-to-use template
+
+#### Configuration properties for Arrowhead Client
+Here you can see the configuration properties which you can use to customize the core service instances. The
+ following scopes exist:
+ * arrowhead.client.consumer: Consumer
+ * arrowhead.client.systems: all
+ * arrowhead.client.orchestration: services which need the orchestrator
+ * arrowhead.client.subscriber: subscriber
+ * arrowhead.client.subscriber: publisher
+
+| Property | Description | Data Type | Default value* | Required |
+| --- | --- | --- | --- | --- |
+| arrowhead.client.system.name | System name | String | | | yes |
+| arrowhead.client.system.interface.secure | secure interface name | String | | yes |
+| arrowhead.client.system.interface.insecure | insecure interface name | String | | yes |
+| arrowhead.client.orchestration.min-version | minimum version of requested services | Integer | 0 | no |
+| arrowhead.client.orchestration.max-version | maximum version of a requested service | Integer | 100 | no |
+| arrowhead.client.orchestration.enable-version | enable search with version | Boolean | false | no |
+| arrowhead.client.orchestration.max-retry | maximum of trials after orchestration request canceled | Integer | 0 | no |
+| arrowhead.client.orchestration.retry-wait | time in seconds to wait after orchestration fails to try again | Integer | 1 | no |
+| arrowhead.client.orchestration.matchmaking | Orchestration Flag; Interface name must match | Boolean | false | no |
+| arrowhead.client.orchestration.override-store | Orchestration Flag; Override Orchestration Store | Boolean | true | no |
+| arrowhead.client.orchestration.metadata-search | Orchestration Flag; search services with metadata | Boolean | true | no |
+| arrowhead.client.orchestration.enable-inter-cloud | Orchestration Flag; search in other Arrowhead Clouds | Boolean | false | no |
+| arrowhead.client.orchestration.enable-qos | Orchestration Flag; activate QoS | Boolean | false | no |
+| arrowhead.client.orchestration.external-service-request | Orchestration Flag; request external services | Boolean | false | no |
+| arrowhead.client.orchestration.only-preferred | Orchestration Flag; return only preferred services | Boolean | false | no |
+| arrowhead.client.orchestration.trigger-inter-cloud | Orchestration Flag; trigger other clouds for requests | Boolean | false | no |
+| arrowhead.client.orchestration.ping-providers | Orchestration Flag; ping providers and only return active services | Boolean | true | no |
+| arrowhead.client.subscriber.base-notification-uri | root URI for RestController; Events will published after subscription to this root (base-notification-uri/eventname) | String | NULL | no |
+| arrowhead.client.subscriber.events.* | events to subscribe (arrowhead.client.subscriber.events.x=y); x stands for an event (case-insensitive); y is the uri of the restcontroller mapping method (case-insensitive) | String | | yes |
+| arrowhead.client.publisher.events.* | events to publish (arrowhead.client.publisher.events.x=y); x is the key identifier in map; y is the name of an event | String | | yes |
+| server.address | IP/Hostname of current system (0.0.0.0 will replaced with all available IP´s) | String | | yes |
+| server.port | Port of the service on the system | Integer | | yes | 
+
+\* empty means necessary
+
+#### Example
+Use the injection interface ``@Autowired`` to bind the variable to the core service class.
+
+```Java
+public class MyClass {
+    @Autowired
+    private ServiceRegistry serviceRegistry;
+
+    public void registerMyService() {
+        Map<String, String> metadata = new HashMap<>();
+
+        //Checking the availability of necessary core systems
+        checkCoreSystemReachability(CoreSystem.SERVICE_REGISTRY);
+
+        if (sslEnabled && tokenSecurityFilterEnabled) {
+            checkCoreSystemReachability(CoreSystem.AUTHORIZATION);			
+    
+            //Initialize Arrowhead Context
+            arrowheadService.updateCoreServiceURIs(CoreSystem.AUTHORIZATION);			
+        
+            setTokenSecurityFilter();
+        }
+
+        // set metadata for service
+        metadata.put("country", "Germany");
+        metadata.put("location", "Dresden");
+        metadata.put("organisation", "HTW Dresden");
+        metadata.put("department", "production");
+        metadata.put("system", "MES");
+        metadata.put("replica", "3");
+
+        // register the service
+        serviceRegistry.registerService("mes-data", "/mes", HttpMethod.GET, metadata);
+    }
+}
+```

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,15 @@
     			<configuration>
     				<skip>true</skip>
     			</configuration>
-  			</plugin>  			  			
-  		</plugins>
+  			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>9</source>
+					<target>9</target>
+				</configuration>
+			</plugin>
+		</plugins>
   	</build>	
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,12 @@
 	    	<artifactId>jose4j</artifactId>
 	    	<version>0.6.5</version>
 	    </dependency>
-		
+
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.8.6</version>
+		</dependency>
 	</dependencies>
 	
 	<build>

--- a/src/main/java/eu/arrowhead/client/library/eventhandler/ConfigEventProperties.java
+++ b/src/main/java/eu/arrowhead/client/library/eventhandler/ConfigEventProperties.java
@@ -1,0 +1,30 @@
+package eu.arrowhead.client.library.eventhandler;
+
+import eu.arrowhead.client.library.model.Events;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+import java.util.Map;
+
+/**
+ * mapping events from application.properties
+ * basic path: arrowhead.client.publisher.events.x=y
+ * basic path: arrowhead.client.subscriber.events.x=y
+ */
+@Configuration
+@PropertySource("classpath:application.properties")
+public class ConfigEventProperties {
+	@Bean
+	@ConfigurationProperties(prefix = "arrowhead.client.publisher.events")
+	public Map<String, String> publisherEvents() {
+		return new Events().getEvents();
+	}
+
+	@Bean
+	@ConfigurationProperties(prefix = "arrowhead.client.subscriber.events")
+	public Map<String, String> subscriberEvents() {
+		return new Events().getEvents();
+	}
+}

--- a/src/main/java/eu/arrowhead/client/library/eventhandler/EventHandler.java
+++ b/src/main/java/eu/arrowhead/client/library/eventhandler/EventHandler.java
@@ -1,0 +1,242 @@
+package eu.arrowhead.client.library.eventhandler;
+
+import eu.arrowhead.client.library.ArrowheadService;
+import eu.arrowhead.common.SSLProperties;
+import eu.arrowhead.common.Utilities;
+import eu.arrowhead.common.dto.shared.EventPublishRequestDTO;
+import eu.arrowhead.common.dto.shared.SubscriptionRequestDTO;
+import eu.arrowhead.common.dto.shared.SystemRequestDTO;
+import eu.arrowhead.common.dto.shared.SystemResponseDTO;
+import eu.arrowhead.common.exception.InvalidParameterException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+import java.util.*;
+
+/**
+ * Event Handler
+ */
+@Component
+public class EventHandler {
+    @Autowired
+    private ArrowheadService arrowheadService;
+
+    @Autowired
+    private ConfigEventProperties configEventProperties;
+
+    @Autowired
+    protected SSLProperties sslProperties;
+
+    @Value("${arrowhead.client.subscriber.base-notification-uri:}")
+    private String baseNotificationUri;
+
+    @Value("${arrowhead.client.system.name}")
+    private String clientSystemName;
+
+    @Value("${server.address}")
+    private String clientSystemAddress;
+
+    @Value("${server.port}")
+    private int clientSystemPort;
+
+    /**
+     * subscribe publisher
+     *
+     * @param events
+     */
+    public void subscribe(Map<String, String> events) {
+        this.subscribe(null, events);
+    }
+
+    /**
+     * subscribe publisher
+     *
+     * @param providers
+     */
+    public void subscribe(final Set<SystemResponseDTO> providers) {
+        this.subscribe(providers, configEventProperties.subscriberEvents());
+    }
+
+    /**
+     * subscribe publisher
+     *
+     * @param providers
+     * @param events
+     */
+    public void subscribe(final Set<SystemResponseDTO> providers, Map<String, String> events) {
+        // subscribe to every defined event in application.properties
+        events.forEach((event, eventUri) -> {
+            if (eventUri.startsWith("/"))
+                eventUri = eventUri.substring(1);
+
+            SubscriptionRequestDTO subscription = this.createSubscriptionRequestDTO(event, this.getInitialSystemDto(), eventUri);
+
+            if (providers != null && !providers.isEmpty())
+                subscription.setSources(this.getSourcesFromProviders(providers));
+
+            // unsubscribe from existing abonnement and resubscribe to it
+            try {
+                this.unsubscribe(event);
+            } catch(InvalidParameterException e) {}
+
+            arrowheadService.subscribeToEventHandler(subscription);
+        });
+    }
+
+    /**
+     * unsubscribe from publisher
+     *
+     * @param event
+     */
+    public void unsubscribe(String event) {
+        arrowheadService.unsubscribeFromEventHandler(event, this.clientSystemName, this.clientSystemAddress, this.clientSystemPort);
+    }
+
+    /**
+     * publish message
+     *
+     * @param event
+     * @param metadata
+     * @param payload
+     */
+    public void publish(String event, Map<String, String> metadata, String payload) {
+        // set timestamp (UTC) and create message object
+        final String timeStamp = Utilities.convertZonedDateTimeToUTCString(ZonedDateTime.now());
+        final EventPublishRequestDTO request = new EventPublishRequestDTO(event, this.getInitialSystemDto(), metadata, payload, timeStamp);
+
+        // publish message
+        arrowheadService.publishToEventHandler(request);
+    }
+
+    /**
+     * return source system information
+     * @param providers
+     * @return
+     */
+    private Set<SystemRequestDTO> getSourcesFromProviders(Set<SystemResponseDTO> providers) {
+        Set<SystemRequestDTO> sources = new HashSet<>(providers.size());
+
+        providers.forEach(provider -> {
+            SystemRequestDTO source = new SystemRequestDTO();
+
+            source.setSystemName(provider.getSystemName());
+            source.setAddress(provider.getAddress());
+            source.setPort(provider.getPort());
+
+            sources.add(source);
+        });
+
+        return sources;
+    }
+
+    /**
+     * fill SubscriptionRequestDTO with information
+     * @param eventType
+     * @param subscriber
+     * @param notificationUri
+     * @return
+     */
+    private SubscriptionRequestDTO createSubscriptionRequestDTO(final String eventType, final SystemRequestDTO subscriber, final String notificationUri) {
+        return createSubscriptionRequestDTO(eventType.toUpperCase(), subscriber, null,
+                notificationUri, false, null, null, null);
+    }
+
+    /**
+     * fill SubscriptionRequestDTO with information
+     * @param eventType
+     * @param subscriber
+     * @param notificationUri
+     * @return
+     */
+    private SubscriptionRequestDTO createSubscriptionRequestDTO(
+            final String eventType,
+            final SystemRequestDTO subscriber,
+            final Map<String, String> filterMetaData,
+            final String notificationUri,
+            boolean matchMetaData,
+            String startDate,
+            String endDate,
+            Set<SystemRequestDTO> sources
+    ) {
+        return new SubscriptionRequestDTO(
+                eventType.toUpperCase(),
+                subscriber,
+                filterMetaData,
+                this.baseNotificationUri + "/" + notificationUri,
+                matchMetaData,
+                startDate,
+                endDate,
+                sources
+        );
+    }
+
+    /**
+     * fill SystemRequestDTO with source system information
+     * @return
+     */
+    private SystemRequestDTO getInitialSystemDto() {
+        final SystemRequestDTO source = new SystemRequestDTO();
+
+        source.setSystemName(this.clientSystemName);
+        source.setAddress(this.clientSystemAddress);
+        source.setPort(this.clientSystemPort);
+
+        // set security information
+        if (sslProperties.isSslEnabled())
+            source.setAuthenticationInfo( Base64.getEncoder().encodeToString(arrowheadService.getMyPublicKey().getEncoded()));
+
+        return source;
+    }
+
+    /**
+     * return event name from given key
+     * @param key
+     * @return
+     */
+    public String getEvent(String key, boolean publisher) {
+        return (publisher ? configEventProperties.publisherEvents().get(key) :
+                configEventProperties.subscriberEvents().get(key));
+    }
+
+    /**
+     * get defined events from configuration
+     * @return
+     */
+    public Map<String, String> getConfigEventProperties(boolean publisher) {
+        return (publisher ? configEventProperties.publisherEvents() : configEventProperties.subscriberEvents());
+    }
+
+    /**
+     * set the base notification uri for event requests
+     * @param baseNotificationUri
+     */
+    public void setBaseNotificationUri(String baseNotificationUri) {
+        this.baseNotificationUri = baseNotificationUri;
+    }
+
+    /**
+     * set the client system name of registering service
+     * @param clientSystemName
+     */
+    public void setClientSystemName(String clientSystemName) {
+        this.clientSystemName = clientSystemName;
+    }
+
+    /**
+     * set client system address of registering service
+     * @param clientSystemAddress
+     */
+    public void setClientSystemAddress(String clientSystemAddress) {
+        this.clientSystemAddress = clientSystemAddress;
+    }
+
+    /**
+     * set client system port of registering service
+     * @param clientSystemPort
+     */
+    public void setClientSystemPort(int clientSystemPort) {
+        this.clientSystemPort = clientSystemPort;
+    }
+}

--- a/src/main/java/eu/arrowhead/client/library/misc/Miscellaneous.java
+++ b/src/main/java/eu/arrowhead/client/library/misc/Miscellaneous.java
@@ -1,0 +1,50 @@
+package eu.arrowhead.client.library.misc;
+
+import eu.arrowhead.common.Utilities;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+/**
+ * Contains various methods that are required for operation or debugging
+ */
+public class Miscellaneous {
+    /**
+     * print objects in pretty JSON to console
+     * @param object
+     */
+    public static void printOut(Object object) {
+        System.out.println(Utilities.toPrettyJson(Utilities.toJson(object)));
+    }
+
+    /**
+     * return all interface addresses from all NICs of the client
+     * @return
+     * @throws SocketException
+     */
+    public static List<InetAddress> getInetAddressesFromNics() throws SocketException {
+        List<InetAddress> addrList = new ArrayList<InetAddress>();
+
+        // iterate through all NIC interfaces
+        for(Enumeration<NetworkInterface> eni = NetworkInterface.getNetworkInterfaces(); eni.hasMoreElements(); ) {
+            final NetworkInterface ifc = eni.nextElement();
+
+            // ignore loopback and down interfaces
+            if(ifc.isUp() && !ifc.isLoopback()) {
+                // iterate throw all addresses of interfaces
+                for (Enumeration<InetAddress> ena = ifc.getInetAddresses(); ena.hasMoreElements(); ) {
+                    InetAddress addr = ena.nextElement();
+
+                    // ignore linklocal and 169.x.x.x addresses
+                    if (!addr.isLinkLocalAddress() && !addr.getHostAddress().matches("169.[0-9]+.[0-9]+.[0-9]+"))
+                        addrList.add(addr);
+                }
+            }
+        }
+
+        return addrList;
+    }
+}

--- a/src/main/java/eu/arrowhead/client/library/model/Events.java
+++ b/src/main/java/eu/arrowhead/client/library/model/Events.java
@@ -1,0 +1,21 @@
+package eu.arrowhead.client.library.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Event mapping class for application.properties
+ * basic path: arrowhead.client.publisher.events.x=y
+ * basic path: arrowhead.client.subscriber.events.x=y
+ */
+public class Events {
+    private Map<String, String> events = new HashMap<>();
+
+    public Map<String, String> getEvents() {
+        return events;
+    }
+
+    public void setEvents(Map<String, String> events) {
+        this.events = events;
+    }
+}

--- a/src/main/java/eu/arrowhead/client/library/orchestrator/Orchestrator.java
+++ b/src/main/java/eu/arrowhead/client/library/orchestrator/Orchestrator.java
@@ -1,0 +1,306 @@
+package eu.arrowhead.client.library.orchestrator;
+
+import eu.arrowhead.client.library.ArrowheadService;
+import eu.arrowhead.common.SSLProperties;
+import eu.arrowhead.common.dto.shared.*;
+import eu.arrowhead.common.dto.shared.OrchestrationFlags.Flag;
+import eu.arrowhead.common.dto.shared.OrchestrationFormRequestDTO.Builder;
+import eu.arrowhead.common.exception.ArrowheadException;
+import eu.arrowhead.common.exception.InvalidParameterException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Orchestrator
+ */
+@Component
+public class Orchestrator {
+    @Autowired
+    private ArrowheadService arrowheadService;
+
+    @Autowired
+    protected SSLProperties sslProperties;
+
+    @Value("${arrowhead.client.system.interface.secure}")
+    private String interfaceSecure;
+    @Value("${arrowhead.client.system.interface.insecure}")
+    private String interfaceInsecure;
+
+    @Value("${arrowhead.client.orchestration.max-retry:0}")
+    private int orchestrationMaxRetry;
+    @Value("${arrowhead.client.orchestration.retry-wait:1}")
+    private int orchestrationRetryWait;
+
+    @Value("${arrowhead.client.orchestration.enable-version:false}")
+    private boolean enableVersion;
+    @Value("${arrowhead.client.orchestration.min-version:0}")
+    private int minVersion;
+    @Value("${arrowhead.client.orchestration.max-version:100}")
+    private int maxVersion;
+
+    @Value("${arrowhead.client.orchestration.matchmaking:false}")
+    private boolean orchestrationOptionMatchmaking;
+    @Value("${arrowhead.client.orchestration.override-store:true}")
+    private boolean orchestrationOptionOverrideStore;
+    @Value("${arrowhead.client.orchestration.metadata-search:true}")
+    private boolean orchestrationOptionMetadataSearch;
+    @Value("${arrowhead.client.orchestration.enable-inter-cloud:false}")
+    private boolean orchestrationOptionEnableInterCloud;
+    @Value("${arrowhead.client.orchestration.enable-qos:false}")
+    private boolean orchestrationOptionEnableQos;
+    @Value("${arrowhead.client.orchestration.external-service-request:false}")
+    private boolean orchestrationOptionExternalServiceRequest;
+    @Value("${arrowhead.client.orchestration.only-preferred:false}")
+    private boolean orchestrationOptionOnlyPreferred;
+    @Value("${arrowhead.client.orchestration.trigger-inter-cloud:false}")
+    private boolean orchestrationOptionTriggerInterCloud;
+    @Value("${arrowhead.client.orchestration.ping-providers:true}")
+    private boolean orchestrationOptionPingProviders;
+
+    /**
+     * request a orchestration
+     *
+     * @param serviceDefinition
+     * @param serviceRequirement
+     * @param httpMethod
+     * @return
+     * @throws ArrowheadException
+     * @throws NullPointerException
+     * @throws InterruptedException
+     */
+    public List<OrchestrationResultDTO> orchestrate(final String serviceDefinition, final String serviceRequirement, HttpMethod httpMethod) throws ArrowheadException, NullPointerException, InterruptedException {
+        return this.orchestrate(serviceDefinition, serviceRequirement, httpMethod, new HashMap<String, String>());
+    }
+
+    /**
+     * request a orchestration
+     *
+     * @param serviceDefinition
+     * @param serviceRequirement
+     * @param httpMethod
+     * @param metadata
+     * @return
+     * @throws ArrowheadException
+     * @throws InterruptedException
+     */
+    public List<OrchestrationResultDTO> orchestrate(final String serviceDefinition, final String serviceRequirement, HttpMethod httpMethod, Map<String, String> metadata) throws ArrowheadException, InterruptedException {
+        int retryCounter = 1;
+        OrchestrationResponseDTO orchestrationResponse = null;
+        ServiceQueryFormDTO serviceQueryForm = null;
+
+        // set service information
+        if (this.enableVersion)
+            serviceQueryForm = new ServiceQueryFormDTO.Builder(serviceDefinition)
+                    .interfaces(serviceRequirement)                         // interface
+                    .version(this.minVersion, this.maxVersion)                        // set service version
+                    .metadata("http-method", httpMethod.name())             // metadata for http method
+                    .metadata(metadata)                                     // set other meta descriptions
+                    .security(ServiceSecurityType.NOT_SECURE)               // set no security information needed
+                    .build();
+        else
+            serviceQueryForm = new ServiceQueryFormDTO.Builder(serviceDefinition)
+                    .interfaces(serviceRequirement)                         // interface
+                    .metadata("http-method", httpMethod.name())             // metadata for http method
+                    .metadata(metadata)                                     // set other meta descriptions
+                    .security(ServiceSecurityType.NOT_SECURE)               // set no security information needed
+                    .build();
+
+        Builder orchestrationFormBuilder = arrowheadService.getOrchestrationFormBuilder();
+
+        // set orchestration flags
+        OrchestrationFormRequestDTO orchestrationFormRequest = orchestrationFormBuilder
+                .requestedService(serviceQueryForm)
+                .flag(Flag.MATCHMAKING, this.orchestrationOptionMatchmaking)                            // return only matched service names
+                .flag(Flag.OVERRIDE_STORE, this.orchestrationOptionOverrideStore)                       // overwrite orchestration store
+                .flag(Flag.METADATA_SEARCH, this.orchestrationOptionMetadataSearch)                     // search with metadata
+                .flag(Flag.ENABLE_INTER_CLOUD, this.orchestrationOptionEnableInterCloud)                // check use other clouds
+                .flag(Flag.ENABLE_QOS, this.orchestrationOptionEnableQos)                               // use QoS
+                .flag(Flag.EXTERNAL_SERVICE_REQUEST, this.orchestrationOptionExternalServiceRequest)
+                .flag(Flag.ONLY_PREFERRED, this.orchestrationOptionOnlyPreferred)                       // only check preferred services
+                .flag(Flag.TRIGGER_INTER_CLOUD, this.orchestrationOptionTriggerInterCloud)              // request other clouds
+                .flag(Flag.PING_PROVIDERS, this.orchestrationOptionPingProviders)                       // ping providers
+                .build();
+
+        //perform requests until is successful or maximum of tries reached
+        do {
+            orchestrationResponse = arrowheadService.proceedOrchestration(orchestrationFormRequest);
+
+            if ((orchestrationResponse == null || orchestrationResponse.getResponse().isEmpty()) && this.orchestrationMaxRetry > 0) {
+                System.err.println("Response from Orchestration is empty or not available");
+                TimeUnit.SECONDS.sleep(this.orchestrationRetryWait);
+            } else
+                break;
+        } while((retryCounter++) < this.orchestrationMaxRetry);
+
+        // throw exception on empty response
+        if (orchestrationResponse == null || orchestrationResponse.getResponse().isEmpty())
+            throw new ArrowheadException("Response from Orchestration is empty or not available");
+
+        // return result
+        return orchestrationResponse.getResponse();
+    }
+
+    /**
+     * validate result of orchestration
+     *
+     * @param orchestrationResult
+     * @param serviceDefinition
+     * @return
+     */
+    public boolean validateOrchestrationResult(final OrchestrationResultDTO orchestrationResult, final String serviceDefinition) {
+        boolean hasValidInterface = false;
+
+        if (!orchestrationResult.getService().getServiceDefinition().equalsIgnoreCase(serviceDefinition))
+            throw new InvalidParameterException("Requested and orchestrated service definition do not match");
+
+        for (final ServiceInterfaceResponseDTO serviceInterface : orchestrationResult.getInterfaces()) {
+            if (serviceInterface.getInterfaceName().equalsIgnoreCase(getInterface())) {
+                hasValidInterface = true;
+                break;
+            }
+        }
+
+        if (!hasValidInterface)
+            throw new InvalidParameterException("Requested and orchestrated interface do not match");
+        else
+            return true;
+    }
+
+    /**
+     * return of the interface to be used
+     * decision based on the "SSL enabled" property
+     *
+     * @return
+     */
+    private String getInterface() {
+        return sslProperties.isSslEnabled() ? interfaceSecure : interfaceInsecure;
+    }
+
+    //-------------------------------------------------------------------------------------------------
+
+    /**
+     * set the secure interface name
+     * @param interfaceSecure
+     */
+    public void setInterfaceSecure(String interfaceSecure) {
+        this.interfaceSecure = interfaceSecure;
+    }
+
+    /**
+     * set the insecure interface name
+     * @param interfaceInsecure
+     */
+    public void setInterfaceInsecure(String interfaceInsecure) {
+        this.interfaceInsecure = interfaceInsecure;
+    }
+
+    /**
+     * set minimum version for requested service
+     * @param minVersion
+     */
+    public void setMinVersion(int minVersion) {
+        this.minVersion = minVersion;
+    }
+
+    /**
+     * set maximum version for requested service
+     * @param maxVersion
+     */
+    public void setMaxVersion(int maxVersion) {
+        this.maxVersion = maxVersion;
+    }
+
+    /**
+     * set the maximum trials until the orchestration request stops if it fails
+     * @param orchestrationMaxRetry
+     */
+    public void setOrchestrationMaxRetry(int orchestrationMaxRetry) {
+        this.orchestrationMaxRetry = orchestrationMaxRetry;
+    }
+
+    /**
+     * set the maximal wait time to wait after an orchestration request fails
+     * @param orchestrationRetryWait
+     */
+    public void setOrchestrationRetryWait(int orchestrationRetryWait) {
+        this.orchestrationRetryWait = orchestrationRetryWait;
+    }
+
+    /**
+     * set orchestration flag for matchmaking
+     * @param orchestrationOptionMatchmaking
+     */
+    public void setOrchestrationOptionMatchmaking(boolean orchestrationOptionMatchmaking) {
+        this.orchestrationOptionMatchmaking = orchestrationOptionMatchmaking;
+    }
+
+    /**
+     * set orchestration flag for overriding store
+     * @param orchestrationOptionOverrideStore
+     */
+    public void setOrchestrationOptionOverrideStore(boolean orchestrationOptionOverrideStore) {
+        this.orchestrationOptionOverrideStore = orchestrationOptionOverrideStore;
+    }
+
+    /**
+     * set orchestration flag for searching with metadata
+     * @param orchestrationOptionMetadataSearch
+     */
+    public void setOrchestrationOptionMetadataSearch(boolean orchestrationOptionMetadataSearch) {
+        this.orchestrationOptionMetadataSearch = orchestrationOptionMetadataSearch;
+    }
+
+    /**
+     * set orchestration flag for enable intercloud searching
+     * @param orchestrationOptionEnableInterCloud
+     */
+    public void setOrchestrationOptionEnableInterCloud(boolean orchestrationOptionEnableInterCloud) {
+        this.orchestrationOptionEnableInterCloud = orchestrationOptionEnableInterCloud;
+    }
+
+    /**
+     * set orchestration flag for enabling QoS
+     * @param orchestrationOptionEnableQos
+     */
+    public void setOrchestrationOptionEnableQos(boolean orchestrationOptionEnableQos) {
+        this.orchestrationOptionEnableQos = orchestrationOptionEnableQos;
+    }
+
+    /**
+     * set orchestration flag for request external services
+     * @param orchestrationOptionExternalServiceRequest
+     */
+    public void setOrchestrationOptionExternalServiceRequest(boolean orchestrationOptionExternalServiceRequest) {
+        this.orchestrationOptionExternalServiceRequest = orchestrationOptionExternalServiceRequest;
+    }
+
+    /**
+     * set orchestration flag for return only preferred services
+     * @param orchestrationOptionOnlyPreferred
+     */
+    public void setOrchestrationOptionOnlyPreferred(boolean orchestrationOptionOnlyPreferred) {
+        this.orchestrationOptionOnlyPreferred = orchestrationOptionOnlyPreferred;
+    }
+
+    /**
+     * set orchestration flag for trigger inter cloud requests
+     * @param orchestrationOptionTriggerInterCloud
+     */
+    public void setOrchestrationOptionTriggerInterCloud(boolean orchestrationOptionTriggerInterCloud) {
+        this.orchestrationOptionTriggerInterCloud = orchestrationOptionTriggerInterCloud;
+    }
+
+    /**
+     * set orchestration flag to ping providers to test if available
+     * @param orchestrationOptionPingProviders
+     */
+    public void setOrchestrationOptionPingProviders(boolean orchestrationOptionPingProviders) {
+        this.orchestrationOptionPingProviders = orchestrationOptionPingProviders;
+    }
+}

--- a/src/main/java/eu/arrowhead/client/library/pojo/SenML.java
+++ b/src/main/java/eu/arrowhead/client/library/pojo/SenML.java
@@ -1,0 +1,260 @@
+package eu.arrowhead.client.library.pojo;
+
+import com.google.gson.Gson;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Sensor Measurement Lists (SenML)
+ * https://tools.ietf.org/html/rfc8428
+ */
+public class SenML implements Serializable {
+    private String bn;
+    private int bt;
+    private String bu;
+    private double bv;
+    private double bs;
+    private int bver;
+    private String n;
+    private String u;
+    private double v;
+    private String vs;
+    private boolean vb;
+    private String vd;
+    private double s;
+    private long t;
+    private long ut;
+
+    /**
+     * empty constructor
+     */
+    public SenML() {
+        this.t = System.currentTimeMillis();
+    }
+
+    /**
+     * minimal required fields
+     * @param n
+     * @param u
+     * @param v
+     */
+    public SenML(String n, String u, double v) {
+        this.n = n;
+        this.u = u;
+        this.v = v;
+    }
+
+    /**
+     * minimal required fields
+     * @param n
+     * @param u
+     * @param vs
+     */
+    public SenML(String n, String u, String vs) {
+        this.n = n;
+        this.u = u;
+        this.vs = vs;
+    }
+
+    /**
+     * minimal required fields
+     * @param n
+     * @param u
+     * @param vb
+     */
+    public SenML(String n, String u, boolean vb) {
+        this.n = n;
+        this.u = u;
+        this.vb = vb;
+    }
+
+    /**
+     * full constructor
+     * @param bn
+     * @param bt
+     * @param bu
+     * @param bv
+     * @param bs
+     * @param bver
+     * @param n
+     * @param u
+     * @param v
+     * @param vs
+     * @param vb
+     * @param vd
+     * @param s
+     * @param t
+     * @param ut
+     */
+    public SenML(String bn, int bt, String bu, double bv, double bs, int bver, String n, String u, double v,
+                 String vs, boolean vb, String vd, double s, long t, long ut) {
+        this.bn = bn;
+        this.bt = bt;
+        this.bu = bu;
+        this.bv = bv;
+        this.bs = bs;
+        this.bver = bver;
+        this.n = n;
+        this.u = u;
+        this.v = v;
+        this.vs = vs;
+        this.vb = vb;
+        this.vd = vd;
+        this.s = s;
+        this.t = t;
+        this.ut = ut;
+    }
+
+    public String getBn() {
+        return bn;
+    }
+
+    public void setBn(String bn) {
+        this.bn = bn;
+    }
+
+    public int getBt() {
+        return bt;
+    }
+
+    public void setBt(int bt) {
+        this.bt = bt;
+    }
+
+    public String getBu() {
+        return bu;
+    }
+
+    public void setBu(String bu) {
+        this.bu = bu;
+    }
+
+    public double getBv() {
+        return bv;
+    }
+
+    public void setBv(double bv) {
+        this.bv = bv;
+    }
+
+    public double getBs() {
+        return bs;
+    }
+
+    public void setBs(double bs) {
+        this.bs = bs;
+    }
+
+    public int getBver() {
+        return bver;
+    }
+
+    public void setBver(int bver) {
+        this.bver = bver;
+    }
+
+    public String getN() {
+        return n;
+    }
+
+    public void setN(String n) {
+        this.n = n;
+    }
+
+    public String getU() {
+        return u;
+    }
+
+    public void setU(String u) {
+        this.u = u;
+    }
+
+    public double getV() {
+        return v;
+    }
+
+    public void setV(double v) {
+        this.v = v;
+    }
+
+    public String getVs() {
+        return vs;
+    }
+
+    public void setVs(String vs) {
+        this.vs = vs;
+    }
+
+    public boolean isVb() {
+        return vb;
+    }
+
+    public void setVb(boolean vb) {
+        this.vb = vb;
+    }
+
+    public String getVd() {
+        return vd;
+    }
+
+    public void setVd(String vd) {
+        this.vd = vd;
+    }
+
+    public double getS() {
+        return s;
+    }
+
+    public void setS(double s) {
+        this.s = s;
+    }
+
+    public long getT() {
+        return t;
+    }
+
+    public void setT(long t) {
+        this.t = t;
+    }
+
+    public long getUt() {
+        return ut;
+    }
+
+    public void setUt(long ut) {
+        this.ut = ut;
+    }
+
+    @Override
+    public String toString() {
+        return new Gson().toJson(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SenML senML = (SenML) o;
+        return Double.compare(senML.bv, bv) == 0 &&
+                Double.compare(senML.bs, bs) == 0 &&
+                bver == senML.bver &&
+                Double.compare(senML.v, v) == 0 &&
+                vb == senML.vb &&
+                Double.compare(senML.s, s) == 0 &&
+                t == senML.t &&
+                ut == senML.ut &&
+                Objects.equals(bn, senML.bn) &&
+                Objects.equals(bt, senML.bt) &&
+                Objects.equals(bu, senML.bu) &&
+                Objects.equals(n, senML.n) &&
+                Objects.equals(u, senML.u) &&
+                Objects.equals(vs, senML.vs) &&
+                Objects.equals(vd, senML.vd);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(bn, bt, bu, bv, bs, bver, n, u, v, vs, vb, vd, s, t, ut);
+    }
+}

--- a/src/main/java/eu/arrowhead/client/library/serviceregistry/ServiceRegistry.java
+++ b/src/main/java/eu/arrowhead/client/library/serviceregistry/ServiceRegistry.java
@@ -155,6 +155,7 @@ public class ServiceRegistry {
 
         systemRequestDTO.setAddress(this.clientSystemAddress);
 
+        // registration attempts with address 0.0.0.0 will be mapped to all available addresses
         if (this.clientSystemAddress.equals("0.0.0.0")) {
             for (InetAddress addr : Miscellaneous.getInetAddressesFromNics()) {
                 systemRequestDTO.setAddress(addr.getHostAddress());

--- a/src/main/java/eu/arrowhead/client/library/serviceregistry/ServiceRegistry.java
+++ b/src/main/java/eu/arrowhead/client/library/serviceregistry/ServiceRegistry.java
@@ -1,0 +1,279 @@
+package eu.arrowhead.client.library.serviceregistry;
+
+import eu.arrowhead.client.library.ArrowheadService;
+import eu.arrowhead.client.library.misc.Miscellaneous;
+import eu.arrowhead.common.dto.shared.ServiceRegistryRequestDTO;
+import eu.arrowhead.common.dto.shared.ServiceSecurityType;
+import eu.arrowhead.common.dto.shared.SystemRequestDTO;
+import eu.arrowhead.common.exception.ArrowheadException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service Registry
+ */
+@Component
+public class ServiceRegistry {
+    @Autowired
+    private ArrowheadService arrowheadService;
+
+    @Value("${arrowhead.client.system.name}")
+    private String clientSystemName;
+    @Value("${server.address}")
+    private String clientSystemAddress;
+    @Value("${server.port}")
+    private int clientSystemPort;
+
+    @Value("${arrowhead.client.system.interface.secure}")
+    private String interfaceSecure;
+    @Value("${arrowhead.client.system.interface.insecure}")
+    private String interfaceInsecure;
+
+    @Value("${server.ssl.enabled:false}")
+    private boolean sslEnabled;
+    @Value("${token.security.filter.enabled:false}")
+    private boolean tokenSecurityFilterEnabled;
+
+    /**
+     * Register a service independent of the client
+     *
+     * @param clientSystemName
+     * @param clientSystemAddress
+     * @param clientSystemPort
+     * @param tokenSecurityFilterEnabled
+     * @param sslEnabled
+     * @param interfaceInsecure
+     * @param interfaceSecure
+     * @param serviceDefinition
+     * @param serviceUri
+     * @param httpMethod
+     * @param metadata
+     */
+    public void registerExternalService(
+            String clientSystemName,
+            String clientSystemAddress,
+            int clientSystemPort,
+            boolean tokenSecurityFilterEnabled,
+            boolean sslEnabled,
+            String interfaceInsecure,
+            String interfaceSecure,
+            String serviceDefinition,
+            String serviceUri,
+            HttpMethod httpMethod,
+            Map<String, String> metadata
+    ) {
+        final ServiceRegistryRequestDTO serviceRegistryRequest = new ServiceRegistryRequestDTO();
+        final SystemRequestDTO systemRequest = new SystemRequestDTO();
+
+        if (clientSystemAddress.matches("169.[0-9]+.[0-9]+.[0-9]+") || clientSystemAddress.equals("0.0.0.0"))
+            throw new ArrowheadException("No link local or meta addresses allowed");
+
+        // set service definition
+        serviceRegistryRequest.setServiceDefinition(serviceDefinition);
+
+        // set system description
+        systemRequest.setSystemName(clientSystemName);
+        systemRequest.setAddress(clientSystemAddress);
+        systemRequest.setPort(clientSystemPort);
+
+        // set interfaces and security description
+        if (tokenSecurityFilterEnabled) {
+            systemRequest.setAuthenticationInfo(Base64.getEncoder().encodeToString(arrowheadService.getMyPublicKey().getEncoded()));
+            serviceRegistryRequest.setSecure(String.valueOf(ServiceSecurityType.TOKEN));
+            serviceRegistryRequest.setInterfaces(List.of(interfaceSecure));
+        } else if (sslEnabled) {
+            systemRequest.setAuthenticationInfo(Base64.getEncoder().encodeToString(arrowheadService.getMyPublicKey().getEncoded()));
+            serviceRegistryRequest.setSecure(String.valueOf(ServiceSecurityType.CERTIFICATE));
+            serviceRegistryRequest.setInterfaces(List.of(interfaceSecure));
+        } else {
+            serviceRegistryRequest.setSecure(String.valueOf(ServiceSecurityType.NOT_SECURE));
+            serviceRegistryRequest.setInterfaces(List.of(interfaceInsecure));
+        }
+
+        serviceRegistryRequest.setProviderSystem(systemRequest);
+        serviceRegistryRequest.setServiceUri(serviceUri);
+        serviceRegistryRequest.setMetadata(new HashMap<>());
+
+        // set meta description
+        if (httpMethod != null)
+            serviceRegistryRequest.getMetadata().put("http-method", httpMethod.name());
+
+        if (metadata != null && !metadata.isEmpty())
+            serviceRegistryRequest.getMetadata().putAll(metadata);
+
+        // Register the service
+        arrowheadService.forceRegisterServiceToServiceRegistry(serviceRegistryRequest);
+    }
+
+    /* --------------------------------------------------------------------------------------------------------------*/
+    /* --------------------------------------------------------------------------------------------------------------*/
+    /* --------------------------------------------------------------------------------------------------------------*/
+
+    /**
+     * register a service
+     * if server.address 0.0.0.0 then it will lookup all available ip´s and register them
+     *
+     * @param serviceDefinition
+     * @param serviceUri
+     */
+    public void register(String serviceDefinition, String serviceUri) throws SocketException {
+        this.register(serviceDefinition, serviceUri, null, null);
+    }
+
+    /**
+     * register a service
+     * if server.address 0.0.0.0 then it will lookup all available ip´s and register them
+     *
+     * @param serviceDefinition
+     * @param serviceUri
+     * @param httpMethod
+     */
+    public void register(String serviceDefinition, String serviceUri, HttpMethod httpMethod) throws SocketException {
+        this.register(serviceDefinition, serviceUri, httpMethod, null);
+    }
+
+    /**
+     * register a service
+     * if server.address 0.0.0.0 then it will lookup all available ip´s and register them
+     *
+     * @param serviceDefinition
+     * @param serviceUri
+     * @param httpMethod
+     * @param metadata
+     */
+    public void register(String serviceDefinition, String serviceUri, HttpMethod httpMethod, Map<String, String> metadata) throws SocketException {
+        SystemRequestDTO systemRequestDTO = new SystemRequestDTO();
+
+        systemRequestDTO.setAddress(this.clientSystemAddress);
+
+        if (this.clientSystemAddress.equals("0.0.0.0")) {
+            for (InetAddress addr : Miscellaneous.getInetAddressesFromNics()) {
+                systemRequestDTO.setAddress(addr.getHostAddress());
+
+                this.register(systemRequestDTO, serviceDefinition, serviceUri, httpMethod, metadata);
+            }
+        } else
+            this.register(systemRequestDTO, serviceDefinition, serviceUri, httpMethod, metadata);
+    }
+
+    /**
+     * register a service
+     *
+     * @param systemRequest
+     * @param serviceDefinition
+     * @param serviceUri
+     * @param httpMethod
+     * @param metadata
+     */
+    private void register(SystemRequestDTO systemRequest, String serviceDefinition, String serviceUri,
+                         HttpMethod httpMethod, Map<String, String> metadata) {
+        final ServiceRegistryRequestDTO serviceRegistryRequest = new ServiceRegistryRequestDTO();
+        serviceRegistryRequest.setServiceDefinition(serviceDefinition);
+
+        // set system description
+        systemRequest.setSystemName(this.clientSystemName);
+        systemRequest.setPort(this.clientSystemPort);
+
+        // set interface and security description
+        if (tokenSecurityFilterEnabled) {
+            systemRequest.setAuthenticationInfo(Base64.getEncoder().encodeToString(arrowheadService.getMyPublicKey().getEncoded()));
+            serviceRegistryRequest.setSecure(String.valueOf(ServiceSecurityType.TOKEN));
+            serviceRegistryRequest.setInterfaces(List.of(this.interfaceSecure));
+        } else if (sslEnabled) {
+            systemRequest.setAuthenticationInfo(Base64.getEncoder().encodeToString(arrowheadService.getMyPublicKey().getEncoded()));
+            serviceRegistryRequest.setSecure(String.valueOf(ServiceSecurityType.CERTIFICATE));
+            serviceRegistryRequest.setInterfaces(List.of(this.interfaceSecure));
+        } else {
+            serviceRegistryRequest.setSecure(String.valueOf(ServiceSecurityType.NOT_SECURE));
+            serviceRegistryRequest.setInterfaces(List.of(this.interfaceInsecure));
+        }
+
+        serviceRegistryRequest.setProviderSystem(systemRequest);
+        serviceRegistryRequest.setServiceUri(serviceUri);
+        serviceRegistryRequest.setMetadata(new HashMap<>());
+
+        // set meta description
+        if (httpMethod != null)
+            serviceRegistryRequest.getMetadata().put("http-method", httpMethod.name());
+
+        if (metadata != null && !metadata.isEmpty())
+            serviceRegistryRequest.getMetadata().putAll(metadata);
+
+        // register a service
+        arrowheadService.forceRegisterServiceToServiceRegistry(serviceRegistryRequest);
+    }
+
+    /**
+     * unregister a service
+     *
+     * @param serviceDefinition
+     */
+    public void unregister(String serviceDefinition) {
+        arrowheadService.unregisterServiceFromServiceRegistry(serviceDefinition);
+    }
+
+    /**
+     * set the client system name of the registering service
+     * @param clientSystemName
+     */
+    public void setClientSystemName(String clientSystemName) {
+        this.clientSystemName = clientSystemName;
+    }
+
+    /**
+     * set the client system addresse of the registering service
+     * @param clientSystemAddress
+     */
+    public void setClientSystemAddress(String clientSystemAddress) {
+        this.clientSystemAddress = clientSystemAddress;
+    }
+
+    /**
+     * set the client system port of the registering service
+     * @param clientSystemPort
+     */
+    public void setClientSystemPort(int clientSystemPort) {
+        this.clientSystemPort = clientSystemPort;
+    }
+
+    /**
+     * set the secure interface name for the registering service
+     * @param interfaceSecure
+     */
+    public void setInterfaceSecure(String interfaceSecure) {
+        this.interfaceSecure = interfaceSecure;
+    }
+
+    /**
+     * set the insecure interface name for the registering service
+     * @param interfaceInsecure
+     */
+    public void setInterfaceInsecure(String interfaceInsecure) {
+        this.interfaceInsecure = interfaceInsecure;
+    }
+
+    /**
+     * set if ssl is enabled on the registering service
+     * @param sslEnabled
+     */
+    public void setSslEnabled(boolean sslEnabled) {
+        this.sslEnabled = sslEnabled;
+    }
+
+    /**
+     * set if token security filter has to be enable
+     * @param tokenSecurityFilterEnabled
+     */
+    public void setTokenSecurityFilterEnabled(boolean tokenSecurityFilterEnabled) {
+        this.tokenSecurityFilterEnabled = tokenSecurityFilterEnabled;
+    }
+}


### PR DESCRIPTION
> Can also be find in README.md

### Changes in this version
* Orchestrator class implemented (request orchestration with this class):
    * use with @Autowired injection
    * orchestration flags can defined via application.properties (changes during runtime always possible)
    * searching with version can be disabled or enabled by application.properties (changes during runtime always possible)
    * minimal and maximal version can defined in application.properties (changes during runtime always possible)
    * it is possible to define how many times the orchestration can fail and how long it has to wait until next try (changes during runtime always possible)
* Service Registry class implemented (request register/unregister a service with this class):
    * use with @Autowired injection
    * register a service or any other services which are not part of the client
    * unregister a service
    * external services cannot register with 0.0.0.0 or 169.x.x.x addresses
    * services with 0.0.0.0 address will be automatically registered with all available addresses
    * defines for this class from application.properties can be changed during runtime
* Event Handler class implemented (publish an/subscribe to/unsubscribe from event with this class):
    * use with @Autowired injection
    * use to register a/subscribe to/unsubscribe from an event
    * predefined options from application.properties can be change during runtime
* ConfigEventProperties class implemented:
    * map defined events in application.properties to Key-Value-Map for Event Handler (automapping)
    * it is used for publisher and subscriber
* implemented SenML class for easy access and as easy-to-use template



Here you can see the configuration properties which you can use to customize the core service instances. The
 following scopes exist:
 * arrowhead.client.consumer: Consumer
 * arrowhead.client.systems: all
 * arrowhead.client.orchestration: services which need the orchestrator
 * arrowhead.client.subscriber: subscriber
 * arrowhead.client.subscriber: publisher

| Property | Description | Data Type | Default value* | Required |
| --- | --- | --- | --- | --- |
| arrowhead.client.system.name | System name | String | | | yes |
| arrowhead.client.system.interface.secure | secure interface name | String | | yes |
| arrowhead.client.system.interface.insecure | insecure interface name | String | | yes |
| arrowhead.client.orchestration.min-version | minimum version of requested services | Integer | 0 | no |
| arrowhead.client.orchestration.max-version | maximum version of a requested service | Integer | 100 | no |
| arrowhead.client.orchestration.enable-version | enable search with version | Boolean | false | no |
| arrowhead.client.orchestration.max-retry | maximum of trials after orchestration request canceled | Integer | 0 | no |
| arrowhead.client.orchestration.retry-wait | time in seconds to wait after orchestration fails to try again | Integer | 1 | no |
| arrowhead.client.orchestration.matchmaking | Orchestration Flag; Interface name must match | Boolean | false | no |
| arrowhead.client.orchestration.override-store | Orchestration Flag; Override Orchestration Store | Boolean | true | no |
| arrowhead.client.orchestration.metadata-search | Orchestration Flag; search services with metadata | Boolean | true | no |
| arrowhead.client.orchestration.enable-inter-cloud | Orchestration Flag; search in other Arrowhead Clouds | Boolean | false | no |
| arrowhead.client.orchestration.enable-qos | Orchestration Flag; activate QoS | Boolean | false | no |
| arrowhead.client.orchestration.external-service-request | Orchestration Flag; request external services | Boolean | false | no |
| arrowhead.client.orchestration.only-preferred | Orchestration Flag; return only preferred services | Boolean | false | no |
| arrowhead.client.orchestration.trigger-inter-cloud | Orchestration Flag; trigger other clouds for requests | Boolean | false | no |
| arrowhead.client.orchestration.ping-providers | Orchestration Flag; ping providers and only return active services | Boolean | true | no |
| arrowhead.client.subscriber.base-notification-uri | root URI for RestController; Events will published after subscription to this root (base-notification-uri/eventname) | String | NULL | no |
| arrowhead.client.subscriber.events.* | events to subscribe (arrowhead.client.subscriber.events.x=y); x stands for an event (case-insensitive); y is the uri of the restcontroller mapping method (case-insensitive) | String | | yes |
| arrowhead.client.publisher.events.* | events to publish (arrowhead.client.publisher.events.x=y); x is the key identifier in map; y is the name of an event | String | | yes |
| server.address | IP/Hostname of current system (0.0.0.0 will replaced with all available IP´s) | String | | yes |
| server.port | Port of the service on the system | Integer | | yes | 

\* empty means necessary