### PR TITLE
Upgrade to Spring Boot v2.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.5.RELEASE</version>
+		<version>2.6.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	
 	<groupId>ai.aitia</groupId>	
 	<artifactId>arrowhead-application-library-java-spring</artifactId>
-	<version>4.4.0.1</version>
+	<version>4.4.0.2</version>
 	<packaging>jar</packaging>
 	
 	<name>application-library-java-spring</name>
@@ -60,10 +60,6 @@
 		<url>http://github.com/eclipse-arrowhead/application-library-java-spring/tree/master</url>
 	</scm>
 	
-	<properties>
-		<log4j2.version>2.17.0</log4j2.version>
-	</properties>
-	
 	<dependencies>
 		<dependency>
   			<groupId>ai.aitia</groupId>
@@ -90,6 +86,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		
 		<dependency>

--- a/src/main/java/ai/aitia/arrowhead/application/library/config/ApplicationInitListener.java
+++ b/src/main/java/ai/aitia/arrowhead/application/library/config/ApplicationInitListener.java
@@ -60,13 +60,6 @@ public abstract class ApplicationInitListener {
 	// methods
 
 	//-------------------------------------------------------------------------------------------------
-	@Bean(CommonConstants.ARROWHEAD_CONTEXT)
-	@DependsOn("ArrowheadService")
-	public Map<String,Object> getArrowheadContext() {
-		return new ConcurrentHashMap<>();
-	}
-	
-	//-------------------------------------------------------------------------------------------------
 	@EventListener
 	@Order(10)
 	public void onApplicationEvent(final ContextRefreshedEvent event) throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException, InterruptedException {

--- a/src/main/java/ai/aitia/arrowhead/application/library/util/ArrowheadContext.java
+++ b/src/main/java/ai/aitia/arrowhead/application/library/util/ArrowheadContext.java
@@ -1,0 +1,13 @@
+package ai.aitia.arrowhead.application.library.util;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+import eu.arrowhead.common.CommonConstants;
+
+@Component(CommonConstants.ARROWHEAD_CONTEXT)
+public class ArrowheadContext extends ConcurrentHashMap<String,Object> {
+
+	private static final long serialVersionUID = -4506616943869170913L;
+}


### PR DESCRIPTION
* Upgrade Spring Boot to v2.6.2 (which is using fixed Log4j)
* Fixing issues coming with the upgrade reported [here](https://github.com/arrowhead-f/client-skeleton-java-spring/issues/31)

Changes has been tested with car-demo example project.